### PR TITLE
Use full Go module path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module cliProxy
+module github.com/djhohnstein/cliProxy
 
 go 1.16
 


### PR DESCRIPTION
Uses full path to the module itself in its `go.mod` file, conventional in Go and compatible with common tooling

Thank you for sharing `cliProxy`! 🙇 